### PR TITLE
fix: set optional validate for field when update/add  user/staff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ packages/
 .vscode/
 /.vs
 /src/Web/Masa.Auth.Web.Admin.Server/Program_develop.cs
+
+.idea
+.DS_Store

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddStaffValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddStaffValidator.cs
@@ -15,7 +15,7 @@ public class AddStaffValidator : AbstractValidator<AddStaffDto>
             .When(u => !string.IsNullOrEmpty(u.Name));
         RuleFor(staff => staff.PhoneNumber).Required().Phone();
         RuleFor(staff => staff.Email).EmailAddress();
-        RuleFor(staff => staff.IdCard).IdCard().When(u => !string.IsNullOrEmpty(u.IdCard));
+        RuleFor(staff => staff.IdCard).IdCard().WithMessage("Id Card format is incorrect").When(u => !string.IsNullOrEmpty(u.IdCard));
         RuleFor(staff => staff.Address.Address).MinimumLength(8).MaximumLength(100).When(u => !string.IsNullOrEmpty(u.Address?.Address));
         RuleFor(staff => staff.CompanyName).ChineseLetter().MaximumLength(50);
         RuleFor(staff => staff.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(50).When(u => !string.IsNullOrEmpty(u.Position));

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddStaffValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddStaffValidator.cs
@@ -11,13 +11,13 @@ public class AddStaffValidator : AbstractValidator<AddStaffDto>
         RuleFor(staff => staff.DisplayName)
             .NotEmpty().WithMessage("NickName is required")
             .ChineseLetterNumber().MinimumLength(2).MaximumLength(50).OverridePropertyName("NickName");
-        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetter().MinimumLength(2).MaximumLength(20));
+        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(20));
         RuleFor(staff => staff.PhoneNumber).Required().Phone();
         RuleFor(staff => staff.Email).Email();
         When(staff => !string.IsNullOrEmpty(staff.IdCard), () => RuleFor(staff => staff.IdCard).IdCard());
-        When(staff => !string.IsNullOrEmpty(staff.Address?.Address), () => RuleFor(staff => staff.IdCard).MinimumLength(8).MaximumLength(100));
-        When(staff => !string.IsNullOrEmpty(staff.CompanyName), () => RuleFor(staff => staff.CompanyName).ChineseLetterNumber().MaximumLength(50));
-        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MaximumLength(20));
+        When(staff => !string.IsNullOrEmpty(staff.Address?.Address), () => RuleFor(staff => staff.Address.Address).MinimumLength(8).MaximumLength(100));
+        When(staff => !string.IsNullOrEmpty(staff.CompanyName), () => RuleFor(staff => staff.CompanyName).ChineseLetter().MaximumLength(50));
+        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(20));
         RuleFor(staff => staff.Password).Required().AuthPassword();
         RuleFor(staff => staff.Avatar).Required().Url();
     }

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddStaffValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddStaffValidator.cs
@@ -11,13 +11,14 @@ public class AddStaffValidator : AbstractValidator<AddStaffDto>
         RuleFor(staff => staff.DisplayName)
             .NotEmpty().WithMessage("NickName is required")
             .ChineseLetterNumber().MinimumLength(2).MaximumLength(50).OverridePropertyName("NickName");
-        RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(50);
+        RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(50)
+            .When(u => !string.IsNullOrEmpty(u.Name));
         RuleFor(staff => staff.PhoneNumber).Required().Phone();
         RuleFor(staff => staff.Email).EmailAddress();
-        RuleFor(staff => staff.IdCard).IdCard();
-        RuleFor(staff => staff.Address.Address).MinimumLength(8).MaximumLength(100);
+        RuleFor(staff => staff.IdCard).IdCard().When(u => !string.IsNullOrEmpty(u.IdCard));
+        RuleFor(staff => staff.Address.Address).MinimumLength(8).MaximumLength(100).When(u => !string.IsNullOrEmpty(u.Address?.Address));
         RuleFor(staff => staff.CompanyName).ChineseLetter().MaximumLength(50);
-        RuleFor(staff => staff.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(50);
+        RuleFor(staff => staff.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(50).When(u => !string.IsNullOrEmpty(u.Position));
         RuleFor(staff => staff.Password).Required().AuthPassword();
         RuleFor(staff => staff.Avatar).Required().Url();
     }

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddStaffValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddStaffValidator.cs
@@ -11,7 +11,7 @@ public class AddStaffValidator : AbstractValidator<AddStaffDto>
         RuleFor(staff => staff.DisplayName)
             .NotEmpty().WithMessage("NickName is required")
             .ChineseLetterNumber().MinimumLength(2).MaximumLength(50).OverridePropertyName("NickName");
-        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(20));
+        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(50));
         RuleFor(staff => staff.PhoneNumber).Required().Phone();
         RuleFor(staff => staff.Email).Email();
         When(staff => !string.IsNullOrEmpty(staff.IdCard), () => RuleFor(staff => staff.IdCard).IdCard());

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddStaffValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddStaffValidator.cs
@@ -11,14 +11,13 @@ public class AddStaffValidator : AbstractValidator<AddStaffDto>
         RuleFor(staff => staff.DisplayName)
             .NotEmpty().WithMessage("NickName is required")
             .ChineseLetterNumber().MinimumLength(2).MaximumLength(50).OverridePropertyName("NickName");
-        RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(50)
-            .When(u => !string.IsNullOrEmpty(u.Name));
+        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetter().MinimumLength(2).MaximumLength(20));
         RuleFor(staff => staff.PhoneNumber).Required().Phone();
-        RuleFor(staff => staff.Email).EmailAddress();
-        RuleFor(staff => staff.IdCard).IdCard().WithMessage("Id Card format is incorrect").When(u => !string.IsNullOrEmpty(u.IdCard));
-        RuleFor(staff => staff.Address.Address).MinimumLength(8).MaximumLength(100).When(u => !string.IsNullOrEmpty(u.Address?.Address));
-        RuleFor(staff => staff.CompanyName).ChineseLetter().MaximumLength(50);
-        RuleFor(staff => staff.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(50).When(u => !string.IsNullOrEmpty(u.Position));
+        RuleFor(staff => staff.Email).Email();
+        When(staff => !string.IsNullOrEmpty(staff.IdCard), () => RuleFor(staff => staff.IdCard).IdCard());
+        When(staff => !string.IsNullOrEmpty(staff.Address?.Address), () => RuleFor(staff => staff.IdCard).MinimumLength(8).MaximumLength(100));
+        When(staff => !string.IsNullOrEmpty(staff.CompanyName), () => RuleFor(staff => staff.CompanyName).ChineseLetterNumber().MaximumLength(50));
+        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MaximumLength(20));
         RuleFor(staff => staff.Password).Required().AuthPassword();
         RuleFor(staff => staff.Avatar).Required().Url();
     }

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddStaffValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddStaffValidator.cs
@@ -17,7 +17,7 @@ public class AddStaffValidator : AbstractValidator<AddStaffDto>
         When(staff => !string.IsNullOrEmpty(staff.IdCard), () => RuleFor(staff => staff.IdCard).IdCard());
         When(staff => !string.IsNullOrEmpty(staff.Address?.Address), () => RuleFor(staff => staff.Address.Address).MinimumLength(8).MaximumLength(100));
         When(staff => !string.IsNullOrEmpty(staff.CompanyName), () => RuleFor(staff => staff.CompanyName).ChineseLetter().MaximumLength(50));
-        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(20));
+        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(50));
         RuleFor(staff => staff.Password).Required().AuthPassword();
         RuleFor(staff => staff.Avatar).Required().Url();
     }

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddUserValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddUserValidator.cs
@@ -13,15 +13,15 @@ public class AddUserValidator : AbstractValidator<AddUserDto>
         RuleFor(user => user.Name).ChineseLetterNumber().MaximumLength(50);
         RuleFor(user => user.PhoneNumber).Required().Phone();
         RuleFor(user => user.Email).Email();
-        RuleFor(user => user.IdCard).IdCard();
-        RuleFor(user => user.CompanyName).ChineseLetterNumber().MinimumLength(2).MaximumLength(50);
-        RuleFor(user => user.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(16);
+        RuleFor(user => user.IdCard).IdCard().WithMessage("Id Card format is incorrect").When(u => !string.IsNullOrEmpty(u.IdCard));
+        RuleFor(user => user.CompanyName).ChineseLetterNumber().MinimumLength(2).MaximumLength(50).When(u => !string.IsNullOrEmpty(u.CompanyName));
+        RuleFor(user => user.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(16).When(u => !string.IsNullOrEmpty(u.Position));
         RuleFor(user => user.Account).Matches("^\\s{0}$|^[\u4e00-\u9fa5_a-zA-Z0-9@.]+$")
                                      .WithMessage("Can only input chinese and letter and number and @ of {PropertyName}")
                                      .MinimumLength(8)
                                      .MaximumLength(50);
         RuleFor(user => user.Password).Required().AuthPassword();
-        RuleFor(user => user.Department).ChineseLetterNumber().MinimumLength(2).MaximumLength(16);
+        RuleFor(user => user.Department).ChineseLetterNumber().MinimumLength(2).MaximumLength(16).When(u => !string.IsNullOrEmpty(u.Department));
         RuleFor(user => user.Avatar).Url().Required();
     }
 }

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddUserValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddUserValidator.cs
@@ -10,18 +10,18 @@ public class AddUserValidator : AbstractValidator<AddUserDto>
         RuleFor(user => user.DisplayName)
            .NotEmpty().WithMessage("NickName is required")
            .Required().ChineseLetterNumber().MaximumLength(50).OverridePropertyName("NickName");
-        RuleFor(user => user.Name).ChineseLetterNumber().MaximumLength(50);
+        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(20));
         RuleFor(user => user.PhoneNumber).Required().Phone();
         RuleFor(user => user.Email).Email();
-        RuleFor(user => user.IdCard).IdCard().WithMessage("Id Card format is incorrect").When(u => !string.IsNullOrEmpty(u.IdCard));
-        RuleFor(user => user.CompanyName).ChineseLetterNumber().MinimumLength(2).MaximumLength(50).When(u => !string.IsNullOrEmpty(u.CompanyName));
-        RuleFor(user => user.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(16).When(u => !string.IsNullOrEmpty(u.Position));
+        When(staff => !string.IsNullOrEmpty(staff.IdCard), () => RuleFor(staff => staff.IdCard).IdCard());
+        When(staff => !string.IsNullOrEmpty(staff.CompanyName), () => RuleFor(staff => staff.CompanyName).ChineseLetterNumber().MaximumLength(50));
+        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MaximumLength(20));
         RuleFor(user => user.Account).Matches("^\\s{0}$|^[\u4e00-\u9fa5_a-zA-Z0-9@.]+$")
                                      .WithMessage("Can only input chinese and letter and number and @ of {PropertyName}")
                                      .MinimumLength(8)
                                      .MaximumLength(50);
         RuleFor(user => user.Password).Required().AuthPassword();
-        RuleFor(user => user.Department).ChineseLetterNumber().MinimumLength(2).MaximumLength(16).When(u => !string.IsNullOrEmpty(u.Department));
+        When(u => !string.IsNullOrEmpty(u.Department), () => RuleFor(user => user.Department).ChineseLetterNumber().MinimumLength(2).MaximumLength(16));
         RuleFor(user => user.Avatar).Url().Required();
     }
 }

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddUserValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddUserValidator.cs
@@ -10,12 +10,12 @@ public class AddUserValidator : AbstractValidator<AddUserDto>
         RuleFor(user => user.DisplayName)
            .NotEmpty().WithMessage("NickName is required")
            .Required().ChineseLetterNumber().MaximumLength(50).OverridePropertyName("NickName");
-        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(20));
+        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(50));
         RuleFor(user => user.PhoneNumber).Required().Phone();
         RuleFor(user => user.Email).Email();
         When(staff => !string.IsNullOrEmpty(staff.IdCard), () => RuleFor(staff => staff.IdCard).IdCard());
-        When(staff => !string.IsNullOrEmpty(staff.CompanyName), () => RuleFor(staff => staff.CompanyName).ChineseLetterNumber().MaximumLength(50));
-        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MaximumLength(20));
+        When(staff => !string.IsNullOrEmpty(staff.CompanyName), () => RuleFor(staff => staff.CompanyName).ChineseLetterNumber().MinimumLength(2).MaximumLength(50));
+        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(16));
         RuleFor(user => user.Account).Matches("^\\s{0}$|^[\u4e00-\u9fa5_a-zA-Z0-9@.]+$")
                                      .WithMessage("Can only input chinese and letter and number and @ of {PropertyName}")
                                      .MinimumLength(8)

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddUserValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/AddUserValidator.cs
@@ -10,12 +10,12 @@ public class AddUserValidator : AbstractValidator<AddUserDto>
         RuleFor(user => user.DisplayName)
            .NotEmpty().WithMessage("NickName is required")
            .Required().ChineseLetterNumber().MaximumLength(50).OverridePropertyName("NickName");
-        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(50));
+        When(user => !string.IsNullOrEmpty(user.Name), () => RuleFor(user => user.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(50));
         RuleFor(user => user.PhoneNumber).Required().Phone();
         RuleFor(user => user.Email).Email();
-        When(staff => !string.IsNullOrEmpty(staff.IdCard), () => RuleFor(staff => staff.IdCard).IdCard());
-        When(staff => !string.IsNullOrEmpty(staff.CompanyName), () => RuleFor(staff => staff.CompanyName).ChineseLetterNumber().MinimumLength(2).MaximumLength(50));
-        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(16));
+        When(user => !string.IsNullOrEmpty(user.IdCard), () => RuleFor(user => user.IdCard).IdCard());
+        When(user => !string.IsNullOrEmpty(user.CompanyName), () => RuleFor(user => user.CompanyName).ChineseLetterNumber().MinimumLength(2).MaximumLength(50));
+        When(user => !string.IsNullOrEmpty(user.Position), () => RuleFor(user => user.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(16));
         RuleFor(user => user.Account).Matches("^\\s{0}$|^[\u4e00-\u9fa5_a-zA-Z0-9@.]+$")
                                      .WithMessage("Can only input chinese and letter and number and @ of {PropertyName}")
                                      .MinimumLength(8)

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateStaffValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateStaffValidator.cs
@@ -11,14 +11,13 @@ public class UpdateStaffValidator : AbstractValidator<UpdateStaffDto>
         RuleFor(staff => staff.DisplayName)
             .NotEmpty().WithMessage("NickName is required")
             .ChineseLetterNumber().MinimumLength(2).MaximumLength(50).OverridePropertyName("NickName");
-        RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(50)
-            .When(u => !string.IsNullOrEmpty(u.Name));
+        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetter().MinimumLength(2).MaximumLength(20));
         RuleFor(staff => staff.PhoneNumber).Required().Phone();
         RuleFor(staff => staff.Email).Email();
-        RuleFor(staff => staff.IdCard).IdCard().WithMessage("Id Card format is incorrect").When(u => !string.IsNullOrEmpty(u.IdCard));
-        RuleFor(staff => staff.Address.Address).MinimumLength(8).MaximumLength(100).When(u => !string.IsNullOrEmpty(u.Address?.Address));
-        RuleFor(staff => staff.CompanyName).ChineseLetter().MinimumLength(50);
-        RuleFor(staff => staff.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(50).When(u => !string.IsNullOrEmpty(u.Position));
+        When(staff => !string.IsNullOrEmpty(staff.IdCard), () => RuleFor(staff => staff.IdCard).IdCard());
+        When(staff => !string.IsNullOrEmpty(staff.Address?.Address), () => RuleFor(staff => staff.IdCard).MinimumLength(8).MaximumLength(100));
+        RuleFor(staff => staff.CompanyName).ChineseLetter().MaximumLength(50);
+        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MaximumLength(20));
         RuleFor(staff => staff.Avatar).Required().Url();
     }
 }

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateStaffValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateStaffValidator.cs
@@ -11,13 +11,13 @@ public class UpdateStaffValidator : AbstractValidator<UpdateStaffDto>
         RuleFor(staff => staff.DisplayName)
             .NotEmpty().WithMessage("NickName is required")
             .ChineseLetterNumber().MinimumLength(2).MaximumLength(50).OverridePropertyName("NickName");
-        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetter().MinimumLength(2).MaximumLength(20));
+        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(50));
         RuleFor(staff => staff.PhoneNumber).Required().Phone();
         RuleFor(staff => staff.Email).Email();
         When(staff => !string.IsNullOrEmpty(staff.IdCard), () => RuleFor(staff => staff.IdCard).IdCard());
-        When(staff => !string.IsNullOrEmpty(staff.Address?.Address), () => RuleFor(staff => staff.IdCard).MinimumLength(8).MaximumLength(100));
+        When(staff => !string.IsNullOrEmpty(staff.Address?.Address), () => RuleFor(staff => staff.Address.Address).MinimumLength(8).MaximumLength(100));
         RuleFor(staff => staff.CompanyName).ChineseLetter().MaximumLength(50);
-        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MaximumLength(20));
+        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(50));
         RuleFor(staff => staff.Avatar).Required().Url();
     }
 }

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateStaffValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateStaffValidator.cs
@@ -11,13 +11,14 @@ public class UpdateStaffValidator : AbstractValidator<UpdateStaffDto>
         RuleFor(staff => staff.DisplayName)
             .NotEmpty().WithMessage("NickName is required")
             .ChineseLetterNumber().MinimumLength(2).MaximumLength(50).OverridePropertyName("NickName");
-        RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(50);
+        RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(50)
+            .When(u => !string.IsNullOrEmpty(u.Name));
         RuleFor(staff => staff.PhoneNumber).Required().Phone();
         RuleFor(staff => staff.Email).Email();
-        RuleFor(staff => staff.IdCard).IdCard();
-        RuleFor(staff => staff.Address.Address).MinimumLength(8).MaximumLength(100);
+        RuleFor(staff => staff.IdCard).IdCard().WithMessage("Id Card format is incorrect").When(u => !string.IsNullOrEmpty(u.IdCard));
+        RuleFor(staff => staff.Address.Address).MinimumLength(8).MaximumLength(100).When(u => !string.IsNullOrEmpty(u.Address?.Address));
         RuleFor(staff => staff.CompanyName).ChineseLetter().MinimumLength(50);
-        RuleFor(staff => staff.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(50);
+        RuleFor(staff => staff.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(50).When(u => !string.IsNullOrEmpty(u.Position));
         RuleFor(staff => staff.Avatar).Required().Url();
     }
 }

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateUserValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateUserValidator.cs
@@ -10,12 +10,12 @@ public class UpdateUserValidator : AbstractValidator<UpdateUserDto>
         RuleFor(user => user.DisplayName)
            .NotEmpty().WithMessage("NickName is required")
            .Required().ChineseLetterNumber().MaximumLength(50).OverridePropertyName("NickName");
-        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(20));
+        When(user => !string.IsNullOrEmpty(user.Name), () => RuleFor(user => user.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(20));
         RuleFor(user => user.PhoneNumber).Required().Phone();
         RuleFor(user => user.Email).Email();
-        When(staff => !string.IsNullOrEmpty(staff.IdCard), () => RuleFor(staff => staff.IdCard).IdCard());
-        When(staff => !string.IsNullOrEmpty(staff.CompanyName), () => RuleFor(staff => staff.CompanyName).ChineseLetterNumber().MaximumLength(50));
-        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MaximumLength(20));
+        When(user => !string.IsNullOrEmpty(user.IdCard), () => RuleFor(user => user.IdCard).IdCard());
+        When(user => !string.IsNullOrEmpty(user.CompanyName), () => RuleFor(user => user.CompanyName).ChineseLetterNumber().MaximumLength(50));
+        When(user => !string.IsNullOrEmpty(user.Position), () => RuleFor(user => user.Position).ChineseLetterNumber().MaximumLength(20));
         RuleFor(user => user.Account).Required()
                                      .Matches("^\\s{0}$|^[\u4e00-\u9fa5_a-zA-Z0-9@.]+$")
                                      .WithMessage("Can only input chinese and letter and number and @ of {PropertyName}")

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateUserValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateUserValidator.cs
@@ -10,12 +10,12 @@ public class UpdateUserValidator : AbstractValidator<UpdateUserDto>
         RuleFor(user => user.DisplayName)
            .NotEmpty().WithMessage("NickName is required")
            .Required().ChineseLetterNumber().MaximumLength(50).OverridePropertyName("NickName");
-        When(user => !string.IsNullOrEmpty(user.Name), () => RuleFor(user => user.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(20));
+        When(user => !string.IsNullOrEmpty(user.Name), () => RuleFor(user => user.Name).ChineseLetterNumber().MaximumLength(50));
         RuleFor(user => user.PhoneNumber).Required().Phone();
         RuleFor(user => user.Email).Email();
         When(user => !string.IsNullOrEmpty(user.IdCard), () => RuleFor(user => user.IdCard).IdCard());
-        When(user => !string.IsNullOrEmpty(user.CompanyName), () => RuleFor(user => user.CompanyName).ChineseLetterNumber().MaximumLength(50));
-        When(user => !string.IsNullOrEmpty(user.Position), () => RuleFor(user => user.Position).ChineseLetterNumber().MaximumLength(20));
+        When(user => !string.IsNullOrEmpty(user.CompanyName), () => RuleFor(user => user.CompanyName).ChineseLetterNumber().MinimumLength(2).MaximumLength(50));
+        When(user => !string.IsNullOrEmpty(user.Position), () => RuleFor(user => user.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(16));
         RuleFor(user => user.Account).Required()
                                      .Matches("^\\s{0}$|^[\u4e00-\u9fa5_a-zA-Z0-9@.]+$")
                                      .WithMessage("Can only input chinese and letter and number and @ of {PropertyName}")

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateUserValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateUserValidator.cs
@@ -10,7 +10,7 @@ public class UpdateUserValidator : AbstractValidator<UpdateUserDto>
         RuleFor(user => user.DisplayName)
            .NotEmpty().WithMessage("NickName is required")
            .Required().ChineseLetterNumber().MaximumLength(50).OverridePropertyName("NickName");
-        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetter().MinimumLength(2).MaximumLength(20));
+        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetterNumber().MinimumLength(2).MaximumLength(20));
         RuleFor(user => user.PhoneNumber).Required().Phone();
         RuleFor(user => user.Email).Email();
         When(staff => !string.IsNullOrEmpty(staff.IdCard), () => RuleFor(staff => staff.IdCard).IdCard());

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateUserValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateUserValidator.cs
@@ -10,18 +10,18 @@ public class UpdateUserValidator : AbstractValidator<UpdateUserDto>
         RuleFor(user => user.DisplayName)
            .NotEmpty().WithMessage("NickName is required")
            .Required().ChineseLetterNumber().MaximumLength(50).OverridePropertyName("NickName");
-        RuleFor(user => user.Name).ChineseLetterNumber().MaximumLength(50);
+        When(staff => !string.IsNullOrEmpty(staff.Name), () => RuleFor(staff => staff.Name).ChineseLetter().MinimumLength(2).MaximumLength(20));
         RuleFor(user => user.PhoneNumber).Required().Phone();
         RuleFor(user => user.Email).Email();
-        RuleFor(user => user.IdCard).IdCard().WithMessage("the IdCard is invalid.").When(u => !string.IsNullOrEmpty(u.IdCard));
-        RuleFor(user => user.CompanyName).ChineseLetterNumber().MinimumLength(2).MaximumLength(50).When(u => !string.IsNullOrEmpty(u.CompanyName));
-        RuleFor(user => user.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(16).When(u => !string.IsNullOrEmpty(u.Position));
+        When(staff => !string.IsNullOrEmpty(staff.IdCard), () => RuleFor(staff => staff.IdCard).IdCard());
+        When(staff => !string.IsNullOrEmpty(staff.CompanyName), () => RuleFor(staff => staff.CompanyName).ChineseLetterNumber().MaximumLength(50));
+        When(staff => !string.IsNullOrEmpty(staff.Position), () => RuleFor(staff => staff.Position).ChineseLetterNumber().MaximumLength(20));
         RuleFor(user => user.Account).Required()
                                      .Matches("^\\s{0}$|^[\u4e00-\u9fa5_a-zA-Z0-9@.]+$")
                                      .WithMessage("Can only input chinese and letter and number and @ of {PropertyName}")
                                      .MinimumLength(8)
                                      .MaximumLength(50);
-        RuleFor(user => user.Department).ChineseLetterNumber().MinimumLength(2).MaximumLength(16).When(u => !string.IsNullOrEmpty(u.Department));
+        When(u => !string.IsNullOrEmpty(u.Department), () => RuleFor(user => user.Department).ChineseLetterNumber().MinimumLength(2).MaximumLength(16));
         RuleFor(user => user.Avatar).Url().Required();
     }
 }

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateUserValidator.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Subjects/Validator/UpdateUserValidator.cs
@@ -13,15 +13,15 @@ public class UpdateUserValidator : AbstractValidator<UpdateUserDto>
         RuleFor(user => user.Name).ChineseLetterNumber().MaximumLength(50);
         RuleFor(user => user.PhoneNumber).Required().Phone();
         RuleFor(user => user.Email).Email();
-        RuleFor(user => user.IdCard).IdCard();
-        RuleFor(user => user.CompanyName).ChineseLetterNumber().MinimumLength(2).MaximumLength(50);
-        RuleFor(user => user.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(16);
+        RuleFor(user => user.IdCard).IdCard().WithMessage("the IdCard is invalid.").When(u => !string.IsNullOrEmpty(u.IdCard));
+        RuleFor(user => user.CompanyName).ChineseLetterNumber().MinimumLength(2).MaximumLength(50).When(u => !string.IsNullOrEmpty(u.CompanyName));
+        RuleFor(user => user.Position).ChineseLetterNumber().MinimumLength(2).MaximumLength(16).When(u => !string.IsNullOrEmpty(u.Position));
         RuleFor(user => user.Account).Required()
                                      .Matches("^\\s{0}$|^[\u4e00-\u9fa5_a-zA-Z0-9@.]+$")
                                      .WithMessage("Can only input chinese and letter and number and @ of {PropertyName}")
                                      .MinimumLength(8)
                                      .MaximumLength(50);
-        RuleFor(user => user.Department).ChineseLetterNumber().MinimumLength(2).MaximumLength(16);
+        RuleFor(user => user.Department).ChineseLetterNumber().MinimumLength(2).MaximumLength(16).When(u => !string.IsNullOrEmpty(u.Department));
         RuleFor(user => user.Avatar).Url().Required();
     }
 }

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/AddStaffCommandValidator.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/AddStaffCommandValidator.cs
@@ -7,14 +7,6 @@ public class AddStaffCommandValidator : AbstractValidator<AddStaffCommand>
 {
     public AddStaffCommandValidator()
     {
-        RuleFor(command => command.Staff.JobNumber).Required().MaximumLength(20);
-        RuleFor(command => command.Staff.DisplayName).MaximumLength(50);
-        RuleFor(command => command.Staff.Name).ChineseLetter().MaximumLength(20);
-        RuleFor(command => command.Staff.PhoneNumber).Required().Phone();
-        RuleFor(command => command.Staff.Email).Email();
-        RuleFor(command => command.Staff.IdCard).IdCard();
-        RuleFor(command => command.Staff.CompanyName).ChineseLetter().MaximumLength(50);
-        RuleFor(command => command.Staff.Position).ChineseLetterNumber().MaximumLength(20);
-        RuleFor(command => command.Staff.Password).AuthPassword();
+        RuleFor(command => command.Staff).SetValidator(new AddStaffValidator());
     }
 }

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/AddStaffCommandValidator.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/AddStaffCommandValidator.cs
@@ -7,6 +7,14 @@ public class AddStaffCommandValidator : AbstractValidator<AddStaffCommand>
 {
     public AddStaffCommandValidator()
     {
-        RuleFor(command => command.Staff).SetValidator(new AddStaffValidator());
+        RuleFor(command => command.Staff.JobNumber).Required().MaximumLength(20);
+        RuleFor(command => command.Staff.DisplayName).MaximumLength(50);
+        When(command => !string.IsNullOrEmpty(command.Staff.Name), () => RuleFor(command => command.Staff.Name).ChineseLetter().MaximumLength(20));
+        RuleFor(command => command.Staff.PhoneNumber).Required().Phone();
+        RuleFor(command => command.Staff.Email).Email();
+        When(command => !string.IsNullOrEmpty(command.Staff.IdCard), () => RuleFor(command => command.Staff.IdCard).IdCard());
+        When(command => !string.IsNullOrEmpty(command.Staff.CompanyName), () => RuleFor(command => command.Staff.CompanyName).ChineseLetterNumber().MaximumLength(50));
+        When(command => !string.IsNullOrEmpty(command.Staff.Position), () => RuleFor(command => command.Staff.Position).ChineseLetterNumber().MaximumLength(20));
+        RuleFor(command => command.Staff.Password).AuthPassword();
     }
 }

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/AddStaffCommandValidator.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/AddStaffCommandValidator.cs
@@ -13,7 +13,7 @@ public class AddStaffCommandValidator : AbstractValidator<AddStaffCommand>
         RuleFor(command => command.Staff.PhoneNumber).Required().Phone();
         RuleFor(command => command.Staff.Email).Email();
         When(command => !string.IsNullOrEmpty(command.Staff.IdCard), () => RuleFor(command => command.Staff.IdCard).IdCard());
-        When(command => !string.IsNullOrEmpty(command.Staff.CompanyName), () => RuleFor(command => command.Staff.CompanyName).ChineseLetterNumber().MaximumLength(50));
+        When(command => !string.IsNullOrEmpty(command.Staff.CompanyName), () => RuleFor(command => command.Staff.CompanyName).ChineseLetter().MaximumLength(50));
         When(command => !string.IsNullOrEmpty(command.Staff.Position), () => RuleFor(command => command.Staff.Position).ChineseLetterNumber().MaximumLength(20));
         RuleFor(command => command.Staff.Password).AuthPassword();
     }

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/AddUserCommandValidator.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/AddUserCommandValidator.cs
@@ -7,6 +7,14 @@ public class AddUserCommandValidator : AbstractValidator<AddUserCommand>
 {
     public AddUserCommandValidator()
     {
-        RuleFor(command => command.User).SetValidator(new AddUserValidator());
+        RuleFor(command => command.User.DisplayName).MaximumLength(50);
+        When(command => !string.IsNullOrEmpty(command.User.Name), () => RuleFor(command => command.User.Name).ChineseLetterNumber().MaximumLength(20));
+        RuleFor(command => command.User.PhoneNumber).Phone();
+        RuleFor(command => command.User.Email).Email();
+        When(command => !string.IsNullOrEmpty(command.User.IdCard), () => RuleFor(command => command.User.IdCard).IdCard());
+        When(command => !string.IsNullOrEmpty(command.User.CompanyName), () => RuleFor(command => command.User.CompanyName).ChineseLetter().MaximumLength(50));
+        When(command => !string.IsNullOrEmpty(command.User.Position), () => RuleFor(command => command.User.Position).ChineseLetterNumber().MaximumLength(20));
+        RuleFor(command => command.User.Account).MaximumLength(50);
+        RuleFor(command => command.User.Password).AuthPassword();
     }
 }

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/AddUserCommandValidator.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/AddUserCommandValidator.cs
@@ -7,14 +7,6 @@ public class AddUserCommandValidator : AbstractValidator<AddUserCommand>
 {
     public AddUserCommandValidator()
     {
-        RuleFor(command => command.User.DisplayName).MaximumLength(50);
-        RuleFor(command => command.User.Name).ChineseLetterNumber().MaximumLength(20);
-        RuleFor(command => command.User.PhoneNumber).Phone();
-        RuleFor(command => command.User.Email).Email();
-        RuleFor(command => command.User.IdCard).IdCard();
-        RuleFor(command => command.User.CompanyName).ChineseLetterNumber().MaximumLength(50);
-        RuleFor(command => command.User.Position).ChineseLetterNumber().MaximumLength(20);
-        RuleFor(command => command.User.Account).MaximumLength(50);
-        RuleFor(command => command.User.Password).AuthPassword();
+        RuleFor(command => command.User).SetValidator(new AddUserValidator());
     }
 }

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/AddUserCommandValidator.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/AddUserCommandValidator.cs
@@ -12,7 +12,7 @@ public class AddUserCommandValidator : AbstractValidator<AddUserCommand>
         RuleFor(command => command.User.PhoneNumber).Phone();
         RuleFor(command => command.User.Email).Email();
         When(command => !string.IsNullOrEmpty(command.User.IdCard), () => RuleFor(command => command.User.IdCard).IdCard());
-        When(command => !string.IsNullOrEmpty(command.User.CompanyName), () => RuleFor(command => command.User.CompanyName).ChineseLetter().MaximumLength(50));
+        When(command => !string.IsNullOrEmpty(command.User.CompanyName), () => RuleFor(command => command.User.CompanyName).ChineseLetterNumber().MaximumLength(50));
         When(command => !string.IsNullOrEmpty(command.User.Position), () => RuleFor(command => command.User.Position).ChineseLetterNumber().MaximumLength(20));
         RuleFor(command => command.User.Account).MaximumLength(50);
         RuleFor(command => command.User.Password).AuthPassword();

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/UpdateStaffCommandValidator.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/UpdateStaffCommandValidator.cs
@@ -7,6 +7,13 @@ public class UpdateStaffCommandValidator : AbstractValidator<UpdateStaffCommand>
 {
     public UpdateStaffCommandValidator()
     {
-        RuleFor(command => command.Staff).SetValidator(new UpdateStaffValidator());
+        RuleFor(command => command.Staff.JobNumber).Required().MaximumLength(20);
+        RuleFor(command => command.Staff.DisplayName).Required().MaximumLength(50);
+        When(command => !string.IsNullOrEmpty(command.Staff.Name), () => RuleFor(command => command.Staff.Name).ChineseLetter().MaximumLength(20));
+        RuleFor(command => command.Staff.PhoneNumber).Required().Phone();
+        RuleFor(command => command.Staff.Email).Email();
+        When(command => !string.IsNullOrEmpty(command.Staff.IdCard), () => RuleFor(command => command.Staff.IdCard).IdCard());
+        RuleFor(command => command.Staff.CompanyName).ChineseLetter().MaximumLength(50);
+        When(command => !string.IsNullOrEmpty(command.Staff.Position), () => RuleFor(command => command.Staff.Position).ChineseLetterNumber().MaximumLength(20));
     }
 }

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/UpdateStaffCommandValidator.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/UpdateStaffCommandValidator.cs
@@ -7,13 +7,6 @@ public class UpdateStaffCommandValidator : AbstractValidator<UpdateStaffCommand>
 {
     public UpdateStaffCommandValidator()
     {
-        RuleFor(command => command.Staff.JobNumber).Required().MaximumLength(20);
-        RuleFor(command => command.Staff.DisplayName).Required().MaximumLength(50);
-        RuleFor(command => command.Staff.Name).ChineseLetter().MaximumLength(20);
-        RuleFor(command => command.Staff.PhoneNumber).Required().Phone();
-        RuleFor(command => command.Staff.Email).Email();
-        RuleFor(command => command.Staff.IdCard).IdCard();
-        RuleFor(command => command.Staff.CompanyName).ChineseLetter().MaximumLength(50);
-        RuleFor(command => command.Staff.Position).ChineseLetterNumber().MaximumLength(20);
+        RuleFor(command => command.Staff).SetValidator(new UpdateStaffValidator());
     }
 }

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/UpdateUserCommandValidator.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/UpdateUserCommandValidator.cs
@@ -7,6 +7,12 @@ public class UpdateUserCommandValidator : AbstractValidator<UpdateUserCommand>
 {
     public UpdateUserCommandValidator()
     {
-        RuleFor(command => command.User).SetValidator(new UpdateUserValidator());
+        RuleFor(command => command.User.DisplayName).Required().MaximumLength(50);
+        RuleFor(command => command.User.Name).ChineseLetterNumber().MaximumLength(20);
+        RuleFor(command => command.User.PhoneNumber).Phone();
+        RuleFor(command => command.User.Email).Email();
+        When(command => !string.IsNullOrEmpty(command.User.IdCard), () => RuleFor(command => command.User.IdCard).IdCard());
+        When(command => !string.IsNullOrEmpty(command.User.CompanyName), () => RuleFor(command => command.User.CompanyName).ChineseLetterNumber().MaximumLength(50));
+        When(command => !string.IsNullOrEmpty(command.User.Position), () => RuleFor(command => command.User.Position).ChineseLetterNumber().MaximumLength(20));
     }
 }

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/UpdateUserCommandValidator.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/UpdateUserCommandValidator.cs
@@ -7,12 +7,6 @@ public class UpdateUserCommandValidator : AbstractValidator<UpdateUserCommand>
 {
     public UpdateUserCommandValidator()
     {
-        RuleFor(command => command.User.DisplayName).Required().MaximumLength(50);
-        RuleFor(command => command.User.Name).ChineseLetterNumber().MaximumLength(20);
-        RuleFor(command => command.User.PhoneNumber).Phone();
-        RuleFor(command => command.User.Email).Email();
-        RuleFor(command => command.User.IdCard).IdCard();
-        RuleFor(command => command.User.CompanyName).ChineseLetterNumber().MaximumLength(50);
-        RuleFor(command => command.User.Position).ChineseLetterNumber().MaximumLength(20);
+        RuleFor(command => command.User).SetValidator(new UpdateUserValidator());
     }
 }


### PR DESCRIPTION
fix: set optional validate for field when update/add  user/staff

1. for user, the idcard、postion、companyName、department  is optional
2. for staff, the idcard、position、name、address is optional
3. update git ignore
4. Service use the same validator with fronted

resolves  #723  #721 #718 #717