### PR TITLE
fix: The field names in the validation message are not translated

### DIFF
--- a/src/Web/Masa.Auth.Web.Admin.Rcl/Pages/Component/PlaceholderTextFiled.cs
+++ b/src/Web/Masa.Auth.Web.Admin.Rcl/Pages/Component/PlaceholderTextFiled.cs
@@ -5,11 +5,17 @@ namespace Masa.Auth.Web.Admin.Rcl.Pages.Component;
 
 public class PlaceholderTextFiled : MTextField<string>
 {
+    public PlaceholderTextFiled()
+    {
+        HideDetails = "auto";
+    }
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
         Class ??= "";
-        Class += " mx-auto";
-        HideDetails = "auto";
+        if (!Class.StartsWith("max-auto "))
+        {
+            Class = "max-auto " + Class;
+        }
     }
 }

--- a/src/Web/Masa.Auth.Web.Admin.Rcl/Shared/MainLayout.razor
+++ b/src/Web/Masa.Auth.Web.Admin.Rcl/Shared/MainLayout.razor
@@ -4,19 +4,46 @@
 @inject IMasaStackConfig MasaStackConfig
 
 <SLayout AppId="@MasaStackConfig.GetWebId(MasaStackConstant.AUTH)" OnErrorAsync="OnError"
-        Logo="https://cdn.masastack.com/stack/images/logo/MASAStack/logo-h-en.png"
-        MiniLogo="https://cdn.masastack.com/stack/images/logo/MASAStack/logo.png">
-        @Body
+         Logo="https://cdn.masastack.com/stack/images/logo/MASAStack/logo-h-en.png"
+         MiniLogo="https://cdn.masastack.com/stack/images/logo/MASAStack/logo.png">
+    @Body
 </SLayout>
 
 @code {
     [Inject]
     public IPopupService PopupService { get; set; } = default!;
 
+    [Inject]
+    public I18n I18N { get; set; } = default!;
+
     Task OnError(Exception exception)
     {
         PopupService.EnqueueSnackbarAsync(exception.Message, AlertTypes.Error);
         GlobalConfig.Loading = false;
         return Task.CompletedTask;
+    }
+
+    protected bool TranslateFluentValidationProperty { get; set; } = true;
+
+    private void UsingI18nToResolveFluentValidationDisplayName(I18n i18N)
+    {
+        ValidatorOptions.Global.DisplayNameResolver = (type, member, expression) =>
+        {
+            if (member != null)
+            {
+                var memberName = i18N.T(member.Name);
+                return memberName;
+            }
+            return null;
+        };
+    }
+
+    protected override Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (TranslateFluentValidationProperty)
+        {
+            UsingI18nToResolveFluentValidationDisplayName(I18N);
+        }
+        return base.OnAfterRenderAsync(firstRender);
     }
 }

--- a/src/Web/Masa.Auth.Web.Admin.Rcl/wwwroot/i18n/zh-CN.json
+++ b/src/Web/Masa.Auth.Web.Admin.Rcl/wwwroot/i18n/zh-CN.json
@@ -588,6 +588,7 @@
   "Password must contain numbers and letter, and not less than 6 digits": "密码必须包含数字和字母，且长度不小于6位数",
   "The password is inconsistent with the confirm password": "密码和确认密码不一致",
   "When file update,need select file again": "当文件更新时，需要重新选择文件",
+  "NickName": "昵称",
   "NickName is required": "昵称必须填写",
   "Please enter a number greater than 8 of Account": "账号请输入大于等于8个字符",
   "Please enter a number less than 50 of Account": "账号请输入小于等于50个字符",


### PR DESCRIPTION
1. call I18n to translate FluentValidationDisplayName
2. fix PlaceholderTextFiled will add class `max-auto` repeatedly
3. add NickName translate
