### PR TITLE
fix:After an employee uploaded a profile picture, the profile picture in the user table was damaged. resolved #781

### DIFF
--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/CommandHandler.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/CommandHandler.cs
@@ -120,6 +120,8 @@ public class CommandHandler
         var user = await VerifyUserRepeatAsync(default, userDto.PhoneNumber, userDto.Email, userDto.IdCard, userDto.Account, !command.WhenExisReturn);
         if (user is not null)
         {
+            await _eventBus.PublishAsync(new UpdateUserAvatarCommand(new UpdateUserAvatarModel(user.Id, command.User.Avatar ?? "")));
+
             command.Result = user;
             return;
         }


### PR DESCRIPTION
创建员工时，如果用户存在，则更新用户的头像