### PR TITLE
Fix: Changing personal information to the phonenumber, send SMS invalid

### DIFF
--- a/src/Services/Masa.Auth.Service.Admin/Application/Messages/CommandHandler.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Messages/CommandHandler.cs
@@ -47,6 +47,7 @@ public class CommandHandler
             case SendMsgCodeTypes.VerifiyPhoneNumber:
                 var user = await CheckUserExistAsync(model.UserId);
                 ArgumentExceptionExtensions.ThrowIfNullOrEmpty(user.PhoneNumber);
+                model.PhoneNumber = user.PhoneNumber;
                 cacheKey = CacheKey.MsgCodeForVerifiyUserPhoneNumberKey(user.Id.ToString(), user.PhoneNumber);
                 break;
             case SendMsgCodeTypes.UpdatePhoneNumber:

--- a/src/Services/Masa.Auth.Service.Admin/Infrastructure/Sms/Sms.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Infrastructure/Sms/Sms.cs
@@ -24,6 +24,8 @@ public class Sms : IScopedDependency
 
     public async Task<string> SendMsgCodeAsync(string key, string phoneNumber, TimeSpan? expiration = null)
     {
+        ArgumentExceptionExtensions.ThrowIfNullOrEmpty(phoneNumber);
+
         var code = Random.Shared.Next(100000, 999999).ToString();
         await _mcClient.MessageTaskService.SendTemplateMessageByExternalAsync(new SendTemplateMessageByExternalModel
         {

--- a/src/Web/Masa.Auth.Web.Sso/Pages/Components/CaptchaSendTextField.razor
+++ b/src/Web/Masa.Auth.Web.Sso/Pages/Components/CaptchaSendTextField.razor
@@ -52,7 +52,10 @@
             var result = await (OnClick.Invoke()).ConfigureAwait(false);
             if (result)
             {
-                await PopupService.EnqueueSnackbarAsync(T("The verification code is sent successfully"), AlertTypes.Success);
+                await InvokeAsync(async () =>
+                {
+                    await PopupService.EnqueueSnackbarAsync(T("The verification code is sent successfully"), AlertTypes.Success);
+                });
                 StartCountdownTimer();
             }
         }


### PR DESCRIPTION
# Description

_1.Changing personal information to the phonenumber, send SMS invalid
  2.SMS.SendMsgCodeAsync add null verification of phone number_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [√] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
