### PR TITLE
Fix: The default password cannot be changed. A message is displayed indicating that the change succeeded --- Issue-866

### DIFF
--- a/src/Services/Masa.Auth.Service.Admin/Program.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Program.cs
@@ -104,7 +104,7 @@ var redisOption = new RedisConfigurationOptions
 builder.Services.AddMultilevelCache(options => options.UseStackExchangeRedisCache(redisOption), multilevel =>
 {
     multilevel.SubscribeKeyType = SubscribeKeyType.SpecificPrefix;
-    multilevel.SubscribeKeyPrefix = $"db-{redisOption.DefaultDatabase}";
+    multilevel.SubscribeKeyPrefix = $"masa.auth:-db-{redisOption.DefaultDatabase}";
 });
 builder.Services.AddAuthClientMultilevelCache(redisOption);
 builder.Services.AddDccClient(redisOption);


### PR DESCRIPTION
Fix [Issue-866](https://github.com/masastack/MASA.Auth/issues/866)