### PR TITLE
fix: when cancel all selected childs, the top permission always show.

### DIFF
--- a/src/Web/Masa.Auth.Web.Admin.Rcl/Pages/Component/Permissions/PermissionExtensionConfigure.cs
+++ b/src/Web/Masa.Auth.Web.Admin.Rcl/Pages/Component/Permissions/PermissionExtensionConfigure.cs
@@ -66,7 +66,7 @@ public class PermissionExtensionConfigure : PermissionsConfigure
 
             var childsCode = EmptyPermissionMap.Where(p => p.Value == parentCode).Select(p => p.Key).ToList();
             var childs = value.IntersectBy(childsCode, p => p.PermissionId).ToList();
-            if (childs.Count == childsCode.Count && childs.All(child => !child.Effect))
+            if (childs.All(child => !child.Effect))
             {
                 parentValue.Add(new(parentCode, false));
             }


### PR DESCRIPTION
fix: when cancel all selected childs, the top permission always show.
![image](https://user-images.githubusercontent.com/45676208/233816847-1d90a00d-ff99-4ce6-a9a3-33c506bac1a8.png)
