### PR TITLE
feat: New function of generating new password and related command processing logic

### DIFF
--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/CommandHandler.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/CommandHandler.cs
@@ -23,6 +23,7 @@ public class CommandHandler
     private readonly LdapDomainService _ldapDomainService;
     private readonly RoleDomainService _roleDomainService;
     private readonly IUserContext _userContext;
+    private readonly PasswordHelper _passwordHelper;
 
     public CommandHandler(
         IUserRepository userRepository,
@@ -42,7 +43,8 @@ public class CommandHandler
         IUnitOfWork unitOfWork,
         LdapDomainService ldapDomainService,
         RoleDomainService roleDomainService,
-        IUserContext userContext)
+        IUserContext userContext,
+        PasswordHelper passwordHelper)
     {
         _userRepository = userRepository;
         _autoCompleteClient = autoCompleteClient;
@@ -62,6 +64,7 @@ public class CommandHandler
         _ldapDomainService = ldapDomainService;
         _roleDomainService = roleDomainService;
         _userContext = userContext;
+        _passwordHelper = passwordHelper;
     }
 
     #region User
@@ -703,5 +706,12 @@ public class CommandHandler
         }
 
         await _userDomainService.RemoveAsync(user.Id);
+    }
+
+    [EventHandler]
+    public async Task GenerateNewPasswordAsync(GenerateNewPasswordCommand command)
+    {
+        command.Result = _passwordHelper.GenerateNewPassword();
+        await Task.CompletedTask;
     }
 }

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/GenerateNewPasswordCommand.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/GenerateNewPasswordCommand.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) MASA Stack All rights reserved.
+// Licensed under the Apache License. See LICENSE.txt in the project root for license information.
+
+namespace Masa.Auth.Service.Admin.Application.Subjects.Commands;
+
+public record GenerateNewPasswordCommand() : Command
+{
+    public string Result { get; set; } = string.Empty;
+}

--- a/src/Services/Masa.Auth.Service.Admin/Services/UserService.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Services/UserService.cs
@@ -422,4 +422,12 @@ public class UserService : ServiceBase
         var command = new DeleteAccountCommand(model.SmsCode);
         await eventBus.PublishAsync(command);
     }
+
+    [RoutePattern("generate-password", StartWithBaseUri = true, HttpMethod = "Post")]
+    public async Task<string> GenerateNewPasswordAsync([FromServices] IEventBus eventBus)
+    {
+        var command = new GenerateNewPasswordCommand();
+        await eventBus.PublishAsync(command);
+        return command.Result;
+    }
 }

--- a/src/Services/Masa.Auth.Service.Admin/_Imports.cs
+++ b/src/Services/Masa.Auth.Service.Admin/_Imports.cs
@@ -15,6 +15,7 @@ global using Masa.Auth.Contracts.Admin.Infrastructure.Constants;
 global using Masa.Auth.Contracts.Admin.Infrastructure.Dtos;
 global using Masa.Auth.Contracts.Admin.Infrastructure.Enums;
 global using Masa.Auth.Contracts.Admin.Infrastructure.Models;
+global using Masa.Auth.Contracts.Admin.Infrastructure.Password;
 global using Masa.Auth.Contracts.Admin.Infrastructure.Phone;
 global using Masa.Auth.Contracts.Admin.Infrastructure.Utils;
 global using Masa.Auth.Contracts.Admin.Logs;


### PR DESCRIPTION
Add the '_passwordHelper' field and related logic in the 'CommandHandler',
It includes constructor parameter injection and the 'GenerateNewPasswordAsync' method.
Add a routing method in 'UserService' to issue a command and return a new password.
The newly added 'GenerateNewPasswordCommand' class is used to define password generation commands.
Update the ` _Imports. cs' file to add the necessary global references.