### PR TITLE
refactor(webhook): rename WebhookEvent to Event

### DIFF
--- a/src/Domain/Masa.Auth.Domain/Webhooks/Aggregates/Webhook.cs
+++ b/src/Domain/Masa.Auth.Domain/Webhooks/Aggregates/Webhook.cs
@@ -17,13 +17,13 @@ public class Webhook : FullAggregateRoot<Guid, Guid>
 
     public bool IsActive { get; private set; } = true;
 
-    public WebhookEvent WebhookEvent { get; private set; }
+    public WebhookEvent Event { get; private set; }
 
     private List<WebhookLog> _webhookLogs = new();
 
     public IReadOnlyCollection<WebhookLog> WebhookLogs => _webhookLogs;
 
-    public Webhook(string name, string url, string httpMethod, string secret, string description, bool isActive, WebhookEvent webhookEvent)
+    public Webhook(string name, string url, string httpMethod, string secret, string description, bool isActive, WebhookEvent @event)
     {
         Name = name;
         Url = url;
@@ -31,17 +31,17 @@ public class Webhook : FullAggregateRoot<Guid, Guid>
         Secret = secret;
         Description = description;
         IsActive = isActive;
-        WebhookEvent = webhookEvent;
+        Event = @event;
     }
 
-    public void Update(string name, string url, string? secret, string? description, bool isActive, WebhookEvent webhookEvent)
+    public void Update(string name, string url, string? secret, string? description, bool isActive, WebhookEvent @event)
     {
         Name = name;
         Url = url;
         Secret = secret ?? Secret;
         Description = description ?? Description;
         IsActive = isActive;
-        WebhookEvent = webhookEvent;
+        Event = @event;
     }
 
     public void AddLog(WebhookLog webhookLog)

--- a/src/Infrastructure/Masa.Auth.EntityFrameworkCore.PostgreSql/EntityConfigurations/Webhooks/WebhookEntityTypeConfiguration.cs
+++ b/src/Infrastructure/Masa.Auth.EntityFrameworkCore.PostgreSql/EntityConfigurations/Webhooks/WebhookEntityTypeConfiguration.cs
@@ -8,7 +8,7 @@ public class WebhookEntityTypeConfiguration : IEntityTypeConfiguration<Webhook>
     public void Configure(EntityTypeBuilder<Webhook> builder)
     {
         builder.HasKey(p => p.Id);
-        builder.Property(p => p.WebhookEvent).HasConversion(
+        builder.Property(p => p.Event).HasConversion(
             v => v.ToString(),
             v => (WebhookEvent)Enum.Parse(typeof(WebhookEvent), v)
         );

--- a/src/Infrastructure/Masa.Auth.EntityFrameworkCore.PostgreSql/Migrations/20250623082724_UpdateWebhookEventFiled.Designer.cs
+++ b/src/Infrastructure/Masa.Auth.EntityFrameworkCore.PostgreSql/Migrations/20250623082724_UpdateWebhookEventFiled.Designer.cs
@@ -4,6 +4,7 @@ using Masa.Auth.Domain.Subjects.Aggregates;
 using Masa.Auth.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Masa.Auth.EntityFrameworkCore.PostgreSql.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250623082724_UpdateWebhookEventFiled")]
+    partial class UpdateWebhookEventFiled
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Masa.Auth.EntityFrameworkCore.PostgreSql/Migrations/20250623082724_UpdateWebhookEventFiled.cs
+++ b/src/Infrastructure/Masa.Auth.EntityFrameworkCore.PostgreSql/Migrations/20250623082724_UpdateWebhookEventFiled.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Masa.Auth.EntityFrameworkCore.PostgreSql.Migrations
+{
+    public partial class UpdateWebhookEventFiled : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "WebhookEvent",
+                schema: "auth",
+                table: "Webhook",
+                newName: "Event");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "Event",
+                schema: "auth",
+                table: "Webhook",
+                newName: "WebhookEvent");
+        }
+    }
+}

--- a/src/Infrastructure/Masa.Auth.EntityFrameworkCore.SqlServer/EntityConfigurations/Webhooks/WebhookEntityTypeConfiguration.cs
+++ b/src/Infrastructure/Masa.Auth.EntityFrameworkCore.SqlServer/EntityConfigurations/Webhooks/WebhookEntityTypeConfiguration.cs
@@ -8,7 +8,7 @@ public class WebhookEntityTypeConfiguration : IEntityTypeConfiguration<Webhook>
     public void Configure(EntityTypeBuilder<Webhook> builder)
     {
         builder.HasKey(p => p.Id);
-        builder.Property(p => p.WebhookEvent).HasConversion(
+        builder.Property(p => p.Event).HasConversion(
             v => v.ToString(),
             v => (WebhookEvent)Enum.Parse(typeof(WebhookEvent), v)
         );

--- a/src/Services/Masa.Auth.Service.Admin/Domain/Webhooks/Services/WebhookDomainService.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Domain/Webhooks/Services/WebhookDomainService.cs
@@ -21,7 +21,7 @@ public class WebhookDomainService : DomainService
 
     public async Task TriggerAsync(WebhookEvent webhookEvent, object data)
     {
-        var webhooks = await _webhookRepository.GetListAsync(w => w.WebhookEvent == webhookEvent && w.IsActive);
+        var webhooks = await _webhookRepository.GetListAsync(w => w.Event == webhookEvent && w.IsActive);
         using var client = new HttpClient();
 
         var payload = new


### PR DESCRIPTION
Updated the `Webhook` class to rename the `WebhookEvent` property to `Event`. This change affects the constructor, update methods, and the entity configuration in `WebhookEntityTypeConfiguration`. Database migration files and model snapshots have also been updated to reflect this property name change.

Additionally, modified the `WebhookDomainService` to query using the new `Event` property name.