### PR TITLE
chore: update package version and simplify JSON handling

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<WarningsAsErrors>
 			$(WarningsAsErrors);CS8600;CS8601;CS8602;CS8603;CS8604;CS8609;CS8610;CS8614;CS8616;CS8618;CS8619;CS8622;CS8625
 		</WarningsAsErrors>
-		<MasaFrameworkPackageVersion>1.2.0-preview.7</MasaFrameworkPackageVersion>
+		<MasaFrameworkPackageVersion>1.2.0-preview.8</MasaFrameworkPackageVersion>
 		<MasaStackSdksPackageVersion>1.2.1-preview.43</MasaStackSdksPackageVersion>
 		<MicrosoftPackageVersion>6.0.7</MicrosoftPackageVersion>
 	</PropertyGroup>

--- a/src/Services/Masa.Auth.Service.Admin/Masa.Auth.Service.Admin.csproj
+++ b/src/Services/Masa.Auth.Service.Admin/Masa.Auth.Service.Admin.csproj
@@ -69,19 +69,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Content Update="Assets\I18n\en-US.json">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </Content>
-	  <Content Update="Assets\I18n\supportedCultures.json">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </Content>
-	  <Content Update="Assets\I18n\ru-RU.json">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </Content>
-	  <Content Update="Assets\I18n\ja-JP.json">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </Content>
-	  <Content Update="Assets\I18n\zh-CN.json">
+	  <Content Update="Assets\I18n\*.json">
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 	  </Content>
 	</ItemGroup>


### PR DESCRIPTION
Updated `MasaFrameworkPackageVersion` from `1.2.0-preview.7` to `1.2.0-preview.8` in `Directory.Build.props`. In `Masa.Auth.Service.Admin.csproj`, replaced multiple JSON content entries with a wildcard entry `Assets\I18n\*.json` to streamline the output directory copying process.