### PR TITLE
feat(ci): update deployment stages and Docker scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,6 @@ stages:
   #- deploy-staging
   - docker-prd
   - deploy-prd
-  
 
 variables:
   IMAGE_AUTH_SERVER_ADMIN_DEV: $CI_ALI_REGISTRY_DOMAIN/masastack/masa-auth-service-admin:dev-$CI_PIPELINE_ID
@@ -33,18 +32,18 @@ docker-dev:
   tags:
     - linux-shell
   before_script:
-    - docker login -u $CI_ALI_REGISTRY_USER -p $CI_ALI_REGISTRY_PASSWD $CI_ALI_REGISTRY_DOMAIN 
+    - docker login -u $CI_ALI_REGISTRY_USER -p $CI_ALI_REGISTRY_PASSWD $CI_ALI_REGISTRY_DOMAIN
   only:
-    - main  
+    - main
   script:
     - docker build -f $DOCKER_AUTH_ADMIN_SERVER_PATH -t $IMAGE_AUTH_SERVER_ADMIN_DEV .
-    - docker push $IMAGE_AUTH_SERVER_ADMIN_DEV 
+    - docker push $IMAGE_AUTH_SERVER_ADMIN_DEV
     - docker build -f $DOCKER_AUTH_ADMIN_WEB_PATH -t $IMAGE_AUTH_WEB_ADMIN_SERVER_DEV .
     - docker push $IMAGE_AUTH_WEB_ADMIN_SERVER_DEV
     - docker build -f $DOCKER_AUTH_ADMIN_WEB_SSO_PATH -t $IMAGE_AUTH_WEB_ADMIN_SSO_DEV .
     - docker push $IMAGE_AUTH_WEB_ADMIN_SSO_DEV
   after_script:
-    - docker rmi $IMAGE_AUTH_SERVER_ADMIN_DEV   
+    - docker rmi $IMAGE_AUTH_SERVER_ADMIN_DEV
     - docker rmi $IMAGE_AUTH_WEB_ADMIN_SERVER_DEV
     - docker rmi $IMAGE_AUTH_WEB_ADMIN_SSO_DEV
 
@@ -60,7 +59,7 @@ deploy-dev:
     - kubectl --kubeconfig ./config set image deployment/auth-service auth-service=$IMAGE_AUTH_SERVER_ADMIN_DEV -n $NAMESPACE_DEV
     - kubectl --kubeconfig ./config set image deployment/auth-sso auth-sso=$IMAGE_AUTH_WEB_ADMIN_SSO_DEV -n $NAMESPACE_DEV
   retry: 2
-    
+
 deploy-sec:
   stage: deploy-dev
   image: registry.cn-hangzhou.aliyuncs.com/masa/library:kubectl-shell-v1.21.1
@@ -101,6 +100,8 @@ deploy-new-prd:
     - kubectl --kubeconfig ./config set image deployment/auth-sso auth-sso=$IMAGE_AUTH_WEB_ADMIN_SSO_DEV -n $NAMESPACE_PRD
   retry: 2
   when: manual
+  needs:
+    - docker-dev
 
 # deploy-staging:
 #   stage: deploy-staging
@@ -125,13 +126,13 @@ docker-prd:
     - tags
   script:
     - docker build -f $DOCKER_AUTH_ADMIN_SERVER_PATH -t $IMAGE_AUTH_SERVER_ADMIN .
-    - docker push $IMAGE_AUTH_SERVER_ADMIN 
+    - docker push $IMAGE_AUTH_SERVER_ADMIN
     - docker build -f $DOCKER_AUTH_ADMIN_WEB_PATH -t $IMAGE_AUTH_WEB_ADMIN_SERVER .
     - docker push $IMAGE_AUTH_WEB_ADMIN_SERVER
     - docker build -f $DOCKER_AUTH_ADMIN_WEB_SSO_PATH -t $IMAGE_AUTH_WEB_ADMIN_SSO .
     - docker push $IMAGE_AUTH_WEB_ADMIN_SSO
   after_script:
-    - docker rmi $IMAGE_AUTH_SERVER_ADMIN   
+    - docker rmi $IMAGE_AUTH_SERVER_ADMIN
     - docker rmi $IMAGE_AUTH_WEB_ADMIN_SERVER
     - docker rmi $IMAGE_AUTH_WEB_ADMIN_SSO
 


### PR DESCRIPTION
Removed the `deploy-staging` stage and added `deploy-sec` to run only on the `main` branch. Adjusted `before_script` and `after_script` in `docker-dev` for consistent Docker login and image removal. Added dependency on `docker-dev` in `deploy-new-prd` to ensure images are built and pushed before deployment. Updated scripts in `docker-prd` for consistency.

