### PR TITLE
feat(QueryHandler): add timestamp to team avatar URLs

### DIFF
--- a/src/Services/Masa.Auth.Service.Admin/Application/Permissions/QueryHandler.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Permissions/QueryHandler.cs
@@ -126,7 +126,7 @@ public class QueryHandler
 
         query.Result = new(
             role.Users.Select(ur => new UserSelectDto(ur.User.Id, ur.User.Name, ur.User.DisplayName, ur.User.Account, ur.User.PhoneNumber, ur.User.Email, ur.User.Avatar)).ToList(),
-            role.Teams.DistinctBy(team => team.TeamId).Select(tr => new TeamSelectDto(tr.Team.Id, tr.Team.Name, tr.Team.Avatar.Url)).ToList()
+            role.Teams.DistinctBy(team => team.TeamId).Select(tr => new TeamSelectDto(tr.Team.Id, tr.Team.Name, $"{tr.Team.Avatar.Url}?stamp={tr.Team.ModificationTime.Second}")).ToList()
         );
     }
 


### PR DESCRIPTION
Updated the `QueryHandler` class in `QueryHandler.cs` to append a timestamp parameter to team avatar URLs. This change ensures that the latest avatar resources are fetched by including the modification time in the URL.