### PR TITLE
feat(OperationLog): Improve operator name handling

### DIFF
--- a/src/Infrastructure/Masa.Auth.EntityFrameworkCore/Repositories/OperationLogRepository.cs
+++ b/src/Infrastructure/Masa.Auth.EntityFrameworkCore/Repositories/OperationLogRepository.cs
@@ -29,9 +29,9 @@ public class OperationLogRepository : Repository<AuthDbContext, OperationLog, Gu
 
             if (@operator is not null && @operator != Guid.Empty)
             {
-                var operatorName = (await _operaterProvider.GetUserAsync(@operator.Value))?.RealDisplayName ?? "";
+                var operatorName = (await _operaterProvider.GetUserAsync(@operator.Value))?.RealDisplayName ?? @operator.ToString();
                 await AddAsync(new OperationLog(
-                    @operator.Value, operatorName, operationType, default, operationDescription
+                    @operator.Value, operatorName!, operationType, default, operationDescription
                 ));
             }
         }
@@ -49,9 +49,9 @@ public class OperationLogRepository : Repository<AuthDbContext, OperationLog, Gu
 
             if (@operator is not null && @operator != Guid.Empty)
             {
-                var operatorName = (await _operaterProvider.GetUserAsync(@operator.Value))?.RealDisplayName ?? "";
+                var operatorName = (await _operaterProvider.GetUserAsync(@operator.Value))?.RealDisplayName ?? @operator.ToString();
                 await AddAsync(new OperationLog(
-                    @operator.Value, operatorName, operationType, default, operationDescription, clientId
+                    @operator.Value, operatorName!, operationType, default, operationDescription, clientId
                 ));
             }
         }

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/OperationLogCommandHandler.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/OperationLogCommandHandler.cs
@@ -19,7 +19,7 @@ namespace Masa.Auth.Service.Admin.Application.Subjects
         [EventHandler]
         public async Task RegisterUserOperationLogAsync(RegisterUserCommand command)
         {
-            await _operationLogRepository.AddDefaultAsync(OperationTypes.RegisterUser, $"注册用户：{command.Result.Account}", command.Result.Id);
+            await _operationLogRepository.AddDefaultAsync(OperationTypes.RegisterUser, $"注册用户：{command.Result.Account}", command.RegisterModel.ClientId, command.Result.Id);
         }
 
         [EventHandler]


### PR DESCRIPTION
Updated the logic for retrieving the operator's name in `OperationLogRepository.cs` to use the operator's string representation if the real display name is null. Also ensured the `clientId` parameter is passed when calling `AddAsync`.

Modified the `RegisterUserOperationLogAsync` method in `OperationLogCommandHandler.cs` to include the `clientId` parameter when logging user registration operations.