### PR TITLE
feat(auth): 添加账户删除功能的邮箱验证码支持

### DIFF
--- a/src/Contracts/Masa.Auth.Contracts.Admin/Infrastructure/Constants/CacheKey.cs
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Infrastructure/Constants/CacheKey.cs
@@ -29,6 +29,8 @@ public static class CacheKey
     const string EMAIL_FORGOT_PASSWORD_SEND_PRE = "email_forgot_password_send:";
     const string MSG_CODE_FORGOT_PASSWORD_CODE_PRE = "msg_forgot_password_code:";
     const string MSG_CODE_FORGOT_PASSWORD_SEND_PRE = "msg_forgot_password_send:";
+    const string EMAIL_DELETE_ACCOUNT_CODE_PRE = "email_delete_account_code:";
+    const string EMAIL_DELETE_ACCOUNT_SEND_PRE = "email_delete_account_send:";
     const string EMAIL_UPDATE_CODE_PRE = "email_update_code:";
     const string EMAIL_UPDATE_SEND_PRE = "email_update_send:";
     public const string STAFF_DEFAULT_PASSWORD = "staff_default_password";
@@ -128,6 +130,16 @@ public static class CacheKey
     public static string EmailCodeForgotPasswordKey(string email)
     {
         return $"{EMAIL_FORGOT_PASSWORD_CODE_PRE}{email}";
+    }
+
+    public static string EmailCodeDeleteAccountSendKey(string email)
+    {
+        return $"{EMAIL_DELETE_ACCOUNT_SEND_PRE}{email}";
+    }
+
+    public static string EmailCodeDeleteAccountKey(string email)
+    {
+        return $"{EMAIL_DELETE_ACCOUNT_CODE_PRE}{email}";
     }
 
     public static string EmailCodeUpdateSendKey(string email)

--- a/src/Contracts/Masa.Auth.Contracts.Admin/Masa.Auth.Contracts.Admin.csproj
+++ b/src/Contracts/Masa.Auth.Contracts.Admin/Masa.Auth.Contracts.Admin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Domain/Masa.Auth.Domain/Masa.Auth.Domain.csproj
+++ b/src/Domain/Masa.Auth.Domain/Masa.Auth.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Infrastructure/Masa.Auth.EntityFrameworkCore.PostgreSql/Masa.Auth.EntityFrameworkCore.PostgreSql.csproj
+++ b/src/Infrastructure/Masa.Auth.EntityFrameworkCore.PostgreSql/Masa.Auth.EntityFrameworkCore.PostgreSql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Infrastructure/Masa.Auth.EntityFrameworkCore.SqlServer/Masa.Auth.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Infrastructure/Masa.Auth.EntityFrameworkCore.SqlServer/Masa.Auth.EntityFrameworkCore.SqlServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Infrastructure/Masa.Auth.EntityFrameworkCore/Masa.Auth.EntityFrameworkCore.csproj
+++ b/src/Infrastructure/Masa.Auth.EntityFrameworkCore/Masa.Auth.EntityFrameworkCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Services/Masa.Auth.Service.Admin/Application/Messages/CommandHandler.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Messages/CommandHandler.cs
@@ -88,6 +88,7 @@ public class CommandHandler
             case SendEmailTypes.Verifiy:
             case SendEmailTypes.UpdateEmail:
             case SendEmailTypes.ForgotPassword:
+            case SendEmailTypes.DeleteAccount:
                 if (!_userRepository.Any(u => u.Email == model.Email))
                 {
                     throw new UserFriendlyException(UserFriendlyExceptionCodes.USER_EMAIL_NOT_EXIST, model.Email);

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/CommandHandler.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/CommandHandler.cs
@@ -714,6 +714,11 @@ public class CommandHandler
             throw new UserFriendlyException(errorCode: UserFriendlyExceptionCodes.USER_NOT_EXIST);
         }
 
+        if (command.SmsCode is not null && command.EmailCode is not null)
+        {
+            throw new UserFriendlyException(errorCode: UserFriendlyExceptionCodes.INVALID_CAPTCHA);
+        }
+
         if (command.SmsCode is not null)
         {
             var smsCodeKey = CacheKey.MsgCodeDeleteAccountKey(user.PhoneNumber);
@@ -721,6 +726,15 @@ public class CommandHandler
             if (!command.SmsCode.Equals(smsCode))
             {
                 throw new UserFriendlyException(errorCode: UserFriendlyExceptionCodes.INVALID_SMS_CAPTCHA);
+            }
+        }
+        else if (command.EmailCode is not null)
+        {
+            var emailCodeKey = CacheKey.EmailCodeDeleteAccountKey(user.Email);
+            var emailCode = await _distributedCacheClient.GetAsync<string>(emailCodeKey);
+            if (!command.EmailCode.Equals(emailCode))
+            {
+                throw new UserFriendlyException(errorCode: UserFriendlyExceptionCodes.INVALID_EMAIL_CAPTCHA);
             }
         }
 

--- a/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/DeleteAccountCommand.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Application/Subjects/Commands/DeleteAccountCommand.cs
@@ -3,6 +3,6 @@
 
 namespace Masa.Auth.Service.Admin.Application.Subjects.Commands;
 
-public record DeleteAccountCommand(string? SmsCode) : Command
+public record DeleteAccountCommand(string? SmsCode, string? EmailCode) : Command
 {
 }

--- a/src/Services/Masa.Auth.Service.Admin/Dockerfile
+++ b/src/Services/Masa.Auth.Service.Admin/Dockerfile
@@ -1,13 +1,13 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM registry.cn-hangzhou.aliyuncs.com/masa/dotnet_sdk:6.0.403 AS publish
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS publish
 WORKDIR /src
 COPY . .
 ENV CSPROJ="src/Services/Masa.Auth.Service.Admin/Masa.Auth.Service.Admin.csproj"
 RUN dotnet restore $CSPROJ && dotnet publish $CSPROJ -c Release -o /app/publish
 
 
-FROM registry.cn-hangzhou.aliyuncs.com/masa/dotnet_aspnet:6.0.4
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENV ASPNETCORE_URLS=http://0.0.0.0:80

--- a/src/Services/Masa.Auth.Service.Admin/Infrastructure/Email/EmailAgent.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Infrastructure/Email/EmailAgent.cs
@@ -47,6 +47,10 @@ public class EmailAgent : IScopedDependency
                 sendKey = CacheKey.EmailCodeBindSendKey(sendEmailModel.Email);
                 sendValueKey = CacheKey.EmailCodeBindKey(sendEmailModel.Email);
                 break;
+            case SendEmailTypes.DeleteAccount:
+                sendKey = CacheKey.EmailCodeDeleteAccountSendKey(sendEmailModel.Email);
+                sendValueKey = CacheKey.EmailCodeDeleteAccountKey(sendEmailModel.Email);
+                break;
             default:
                 break;
         }

--- a/src/Services/Masa.Auth.Service.Admin/Masa.Auth.Service.Admin.csproj
+++ b/src/Services/Masa.Auth.Service.Admin/Masa.Auth.Service.Admin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<UserSecretsId>6efa3c5e-9868-4abd-90a1-75aca8b7b38f</UserSecretsId>

--- a/src/Services/Masa.Auth.Service.Admin/Services/OnlineUserService.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Services/OnlineUserService.cs
@@ -42,7 +42,7 @@ public class OnlineUserService : ServiceBase
             var sessionJson = await db.StringGetAsync(SsoSessionKey(subjectId));
             if (sessionJson.HasValue)
             {
-                var session = JsonSerializer.Deserialize<WebOnlineSessionDto>(sessionJson!);
+                var session = JsonSerializer.Deserialize<WebOnlineSessionDto>((string)sessionJson!);
                 if (session != null)
                     webSessions[subjectId] = new WebSessionDto(session.LoginTime, session.ClientId);
             }

--- a/src/Services/Masa.Auth.Service.Admin/Services/UserService.cs
+++ b/src/Services/Masa.Auth.Service.Admin/Services/UserService.cs
@@ -434,7 +434,7 @@ public class UserService : ServiceBase
     [RoutePattern("account/delete", StartWithBaseUri = true, HttpMethod = "Post")]
     public async Task DeleteAccountAsync([FromServices] IEventBus eventBus, [FromBody] DeleteAccountModel model)
     {
-        var command = new DeleteAccountCommand(model.SmsCode);
+        var command = new DeleteAccountCommand(model.SmsCode, model.EmailCode);
         await eventBus.PublishAsync(command);
     }
 

--- a/src/Web/Masa.Auth.Security.OAuth.Providers/Masa.Auth.Security.OAuth.Providers.csproj
+++ b/src/Web/Masa.Auth.Security.OAuth.Providers/Masa.Auth.Security.OAuth.Providers.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/Web/Masa.Auth.Web.Sso/Dockerfile
+++ b/src/Web/Masa.Auth.Web.Sso/Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.cn-hangzhou.aliyuncs.com/masa/dotnet_sdk:6.0.403 AS publish
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS publish
 WORKDIR /src
 COPY . .
 ENV CSPROJ="src/Web/Masa.Auth.Web.Sso/Masa.Auth.Web.Sso.csproj"
 RUN dotnet restore $CSPROJ && dotnet publish $CSPROJ -c Release -o /app/publish
 
-FROM registry.cn-hangzhou.aliyuncs.com/masa/dotnet_aspnet:6.0.4
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENV ASPNETCORE_URLS=https://0.0.0.0:443

--- a/src/Web/Masa.Auth.Web.Sso/Masa.Auth.Web.Sso.csproj
+++ b/src/Web/Masa.Auth.Web.Sso/Masa.Auth.Web.Sso.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<ServerGarbageCollection>false</ServerGarbageCollection>


### PR DESCRIPTION
- 升级所有项目的目标框架从 net6.0 到 net10.0
- 在缓存键常量中添加账户删除相关的邮箱验证码前缀
- 扩展 SendEmailTypes.DeleteAccount 类型的邮件发送逻辑
- 修改 DeleteAccountCommand 命令以支持邮箱验证码参数
- 在用户服务中实现账户删除时的邮箱验证码验证
- 修复在线用户会话反序列化中的类型转换问题
- 添加对同时提供短信和邮箱验证码的冲突检查